### PR TITLE
Use centralized metadata config

### DIFF
--- a/app/about/page.js
+++ b/app/about/page.js
@@ -1,10 +1,7 @@
 import Reviews from '@/components/testimonials/Testimonials_1'
+import { siteConfig } from '@/config/siteConfig'
 
-export const metadata = {
-  title: "About | Wheldrakes",
-  description:
-    "Learn more about Wheldrakes Café in York – our story, our passion for fresh food and coffee, and the people behind the scenes.",
-};
+export const metadata = siteConfig.metadata.about;
 
 export default function AboutPage() {
   return (

--- a/app/contact/page.js
+++ b/app/contact/page.js
@@ -1,10 +1,8 @@
 import Image from 'next/image';
 import FindUs from '@/components/findus/FindUs_1';
+import { siteConfig } from '@/config/siteConfig';
 
-export const metadata = {
-  title: 'Contact Us | Wheldrakes York',
-  description: 'Find our café, contact us via phone or email, and see where we are in York.',
-};
+export const metadata = siteConfig.metadata.contact;
 
 export default function ContactPage() {
   return (

--- a/app/gallery/page.js
+++ b/app/gallery/page.js
@@ -1,10 +1,8 @@
 import Gallery from "@/components/gallery/Gallery_1";
 import Location from '@/components/findus/FindUs_1'
+import { siteConfig } from '@/config/siteConfig'
 
-export const metadata = {
-  title: "Gallery | Wheldrakes",
-  description: "Browse our cosy café, brunch plates, cakes and more from Wheldrakes in York.",
-};
+export const metadata = siteConfig.metadata.gallery;
 
 export default function GalleryPage() {
   return (

--- a/app/layout.js
+++ b/app/layout.js
@@ -3,6 +3,7 @@ import { Inter, Playpen_Sans } from 'next/font/google';
 import Nav from '@/components/navigation/Nav_1';
 import Footer from '@/components/footer/Footer_1';
 import Banner from '@/components/banner/Banner_1';
+import { siteConfig } from '@/config/siteConfig';
 
 const inter = Inter({ subsets: ['latin'], variable: '--font-inter' });
 const playpen = Playpen_Sans({
@@ -11,14 +12,7 @@ const playpen = Playpen_Sans({
   variable: '--font-playpen',
 });
 
-export const metadata = {
-  title: 'Wheldrakes – Artisan Coffee & Brunch in York',
-  description:
-    'Wheldrakes is a beloved independent café in York, serving artisan coffee, fresh brunch, and homemade treats in a cosy, relaxed setting just minutes from York Minster.',
-  icons: {
-    icon: '/favicon.ico',
-  },
-};
+export const metadata = siteConfig.metadata.base;
 
 export default function RootLayout({ children }) {
   return (

--- a/config/siteConfig.js
+++ b/config/siteConfig.js
@@ -4,6 +4,33 @@ export const siteConfig = {
   // Site Name
   siteName: 'The Jester Berkhamsted',
 
+  // Metadata used across Next.js pages
+  metadata: {
+    base: {
+      title: 'Wheldrakes – Artisan Coffee & Brunch in York',
+      description:
+        'Wheldrakes is a beloved independent café in York, serving artisan coffee, fresh brunch, and homemade treats in a cosy, relaxed setting just minutes from York Minster.',
+      icons: {
+        icon: '/favicon.ico',
+      },
+    },
+    about: {
+      title: 'About | Wheldrakes',
+      description:
+        'Learn more about Wheldrakes Café in York – our story, our passion for fresh food and coffee, and the people behind the scenes.',
+    },
+    contact: {
+      title: 'Contact Us | Wheldrakes York',
+      description:
+        'Find our café, contact us via phone or email, and see where we are in York.',
+    },
+    gallery: {
+      title: 'Gallery | Wheldrakes',
+      description:
+        'Browse our cosy café, brunch plates, cakes and more from Wheldrakes in York.',
+    },
+  },
+
   // Font settings (used for global Tailwind utility control)
   fonts: {
     base: `'Inter', sans-serif`,                  // For body text


### PR DESCRIPTION
## Summary
- add metadata definitions to `config/siteConfig.js`
- pull metadata from `siteConfig` in `app/layout.js`
- update About, Contact and Gallery pages to use the config values

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_68555f7c71f48321b34faac23b86b0cd