### PR TITLE
Allow fonts via site config

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,3 +34,25 @@ You can check out [the Next.js GitHub repository](https://github.com/vercel/next
 The easiest way to deploy your Next.js app is to use the [Vercel Platform](https://vercel.com/new?utm_medium=default-template&filter=next.js&utm_source=create-next-app&utm_campaign=create-next-app-readme) from the creators of Next.js.
 
 Check out our [Next.js deployment documentation](https://nextjs.org/docs/app/building-your-application/deploying) for more details.
+
+## Font Configuration
+
+Fonts are defined in `config/siteConfig.js` under the `fonts` key. Each Google
+font specifies the `family` name as exported from
+[`next/font/google`](https://nextjs.org/docs/app/building-your-application/optimizing/fonts)
+and an array of `weights` to load:
+
+```js
+fonts: {
+  base: `'Inter', sans-serif`,
+  heading: `'Playfair Display', serif`,
+  baseClass: 'font-sans',
+  headingClass: 'font-serif',
+  google: {
+    base: { family: 'Inter', weights: ['400'] },
+    heading: { family: 'Playpen_Sans', weights: ['400'] },
+  },
+}
+```
+
+`app/layout.js` reads these values to load the appropriate fonts.

--- a/app/layout.js
+++ b/app/layout.js
@@ -1,12 +1,22 @@
 import './globals.css';
-import { Inter, Playpen_Sans } from 'next/font/google';
+import { Inter, Playpen_Sans, Playfair_Display } from 'next/font/google';
 import Nav from '@/components/navigation/Nav_1';
 import Footer from '@/components/footer/Footer_1';
 import Banner from '@/components/banner/Banner_1';
+import { siteConfig } from '@/config/siteConfig';
 
-const inter = Inter({ subsets: ['latin'], variable: '--font-inter' });
-const playpen = Playpen_Sans({
-  weight: '400',
+const fontMap = { Inter, Playpen_Sans, Playfair_Display };
+const baseFont = siteConfig.fonts.google.base;
+const headingFont = siteConfig.fonts.google.heading;
+
+const inter = fontMap[baseFont.family]({
+  weight: baseFont.weights,
+  subsets: ['latin'],
+  variable: '--font-inter',
+});
+
+const playpen = fontMap[headingFont.family]({
+  weight: headingFont.weights,
   subsets: ['latin'],
   variable: '--font-playpen',
 });

--- a/config/siteConfig.js
+++ b/config/siteConfig.js
@@ -10,6 +10,10 @@ export const siteConfig = {
     heading: `'Playfair Display', serif`,         // For headings if needed
     baseClass: 'font-sans',                       // Tailwind utility for base text
     headingClass: 'font-serif',                   // Tailwind utility for styled headings
+    google: {
+      base: { family: 'Inter', weights: ['400'] },
+      heading: { family: 'Playpen_Sans', weights: ['400'] },
+    },
   },
 
   // Brand Colours (used in components as visual identity)


### PR DESCRIPTION
## Summary
- support selecting Google fonts and weights through `siteConfig`
- read font info from config in the layout
- document how to configure fonts

## Testing
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_68555f8adf6083218d2c48f47e4cf514