### PR TITLE
Fix Google font loader usage

### DIFF
--- a/app/layout.js
+++ b/app/layout.js
@@ -1,5 +1,5 @@
 import './globals.css';
-import { Inter, Playpen_Sans } from 'next/font/google';
+import { Inter, Playpen_Sans, Playfair_Display } from 'next/font/google';
 import Nav from '@/components/navigation/Nav_1';
 import Footer from '@/components/footer/Footer_1';
 import Banner from '@/components/banner/Banner_1';
@@ -11,13 +11,30 @@ const playpen = Playpen_Sans({
   subsets: ['latin'],
   variable: '--font-playpen',
 });
+const playfair = Playfair_Display({
+  weight: '400',
+  subsets: ['latin'],
+  variable: '--font-playfair',
+});
+
+const fontMap = {
+  Inter: inter,
+  Playpen_Sans: playpen,
+  Playfair_Display: playfair,
+};
+
+const baseFont = fontMap[siteConfig.fonts.google.base];
+const headingFont = fontMap[siteConfig.fonts.google.heading];
+const accentFont = fontMap[siteConfig.fonts.google.accent];
 
 export const metadata = siteConfig.metadata.base;
 
 export default function RootLayout({ children }) {
   return (
     <html lang="en">
-      <body className={`${inter.variable} ${playpen.variable} font-sans antialiased`}>
+      <body
+        className={`${baseFont.variable} ${headingFont.variable} ${accentFont ? accentFont.variable : ''} ${siteConfig.fonts.baseClass} antialiased`}
+      >
         <Banner />
         <Nav />
         <main>{children}</main>

--- a/config/siteConfig.js
+++ b/config/siteConfig.js
@@ -37,6 +37,11 @@ export const siteConfig = {
     heading: `'Playfair Display', serif`,         // For headings if needed
     baseClass: 'font-sans',                       // Tailwind utility for base text
     headingClass: 'font-serif',                   // Tailwind utility for styled headings
+    google: {
+      base: 'Inter',
+      heading: 'Playfair_Display',
+      accent: 'Playpen_Sans',
+    },
   },
 
   // Brand Colours (used in components as visual identity)


### PR DESCRIPTION
## Summary
- load Playfair Display in addition to Inter and Playpen Sans
- allow selecting fonts via `siteConfig`

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_685563914bc48321a075f5ae8944d085