### PR TITLE
Brand site as Seaside Brew

### DIFF
--- a/app/about/page.js
+++ b/app/about/page.js
@@ -7,10 +7,10 @@ export default function AboutPage() {
   return (
     <main className="bg-[#f9f7f4] py-24 px-6 md:px-12 text-gray-800">
       <div className="max-w-4xl mx-auto text-center mb-16">
-        <h1 className="text-4xl md:text-5xl font-extrabold text-[#4b2e2e] mb-6">Our Story</h1>
+        <h1 className="text-4xl md:text-5xl font-extrabold text-sky-900 mb-6">Our Story</h1>
         <p className="text-lg text-gray-700">
-          Nestled in the heart of York, Wheldrakes is an independent, family-run café dedicated to quality, comfort, and community. 
-          Whether you're after the perfect flat white, a warm scone fresh from the oven, or a place to slow down — 
+          Tucked just off Brighton's famous seafront, Seaside Brew is an independent, family-run café dedicated to quality, comfort and community.
+          Whether you're after the perfect flat white, a warm scone fresh from the oven or a spot to unwind after a beach stroll —
           we're here to serve it, and serve it well.
         </p>
       </div>
@@ -18,27 +18,27 @@ export default function AboutPage() {
       <div className="max-w-5xl mx-auto grid grid-cols-1 md:grid-cols-2 gap-12 items-start">
         {/* Mission */}
         <div>
-          <h2 className="text-2xl font-semibold mb-3 text-[#4b2e2e]">Made Daily, Served with Care</h2>
+          <h2 className="text-2xl font-semibold mb-3 text-sky-900">Made Daily, Served with Care</h2>
           <p className="text-gray-700 leading-relaxed">
-            Every dish at Wheldrakes is made from scratch using locally sourced ingredients wherever possible. 
-            We believe in doing things the right way — slow-roasted coffee, handmade cakes, and a brunch menu 
+            Every dish at Seaside Brew is made from scratch using locally sourced ingredients wherever possible.
+            We believe in doing things the right way — slow-roasted coffee, homemade cakes and a brunch menu
             that changes with the seasons.
           </p>
         </div>
 
         {/* Family/Local focus */}
         <div>
-          <h2 className="text-2xl font-semibold mb-3 text-[#4b2e2e]">Rooted in York</h2>
+          <h2 className="text-2xl font-semibold mb-3 text-sky-900">Rooted in Brighton</h2>
           <p className="text-gray-700 leading-relaxed">
-            Wheldrakes has been a part of the Goodramgate community for years. We're proud to be part of York’s 
-            independent food scene — a place where locals, students, and tourists alike can feel at home. 
+            Seaside Brew is proud to be part of Brighton’s bustling Lanes community.
+            We’re a place where locals, students and visitors alike can feel at home.
             Whether you’re here every weekend or visiting for the first time, our door’s always open.
           </p>
         </div>
 
         {/* Commitment */}
         <div>
-          <h2 className="text-2xl font-semibold mb-3 text-[#4b2e2e]">Sustainable & Simple</h2>
+          <h2 className="text-2xl font-semibold mb-3 text-sky-900">Sustainable & Simple</h2>
           <p className="text-gray-700 leading-relaxed">
             We keep things simple: no fuss, no fluff. Just proper coffee, honest food, and friendly service. 
             Sustainability matters to us too — we aim to reduce waste, support local suppliers, and keep our 
@@ -48,7 +48,7 @@ export default function AboutPage() {
 
         {/* Invitation */}
         <div>
-          <h2 className="text-2xl font-semibold mb-3 text-[#4b2e2e]">Pop In Sometime</h2>
+          <h2 className="text-2xl font-semibold mb-3 text-sky-900">Pop In Sometime</h2>
           <p className="text-gray-700 leading-relaxed">
             We’re here seven days a week with fresh bakes, warm smiles, and plenty of seating inside and out. 
             Whether it’s your morning ritual or a weekend catch-up, we can’t wait to welcome you.

--- a/app/contact/page.js
+++ b/app/contact/page.js
@@ -10,7 +10,7 @@ export default function ContactPage() {
       {/* Intro Section */}
       <section className="bg-[#f9f7f4] py-24 px-6 md:px-12">
         <div className="max-w-7xl mx-auto text-center">
-          <h1 className="text-4xl md:text-5xl font-bold text-[#4b2e2e] mb-6">We’d Love to Hear from You</h1>
+          <h1 className="text-4xl md:text-5xl font-bold text-sky-900 mb-6">We’d Love to Hear from You</h1>
           <p className="text-lg text-gray-700 max-w-2xl mx-auto">
             Whether you’re booking a table, asking about allergens, or just saying hello — we’re always here.
           </p>
@@ -23,22 +23,22 @@ export default function ContactPage() {
           
           {/* Left: Contact Details */}
           <div>
-            <h2 className="text-2xl font-semibold text-[#4b2e2e] mb-6">Where to Find Us</h2>
+            <h2 className="text-2xl font-semibold text-sky-900 mb-6">Where to Find Us</h2>
             <p className="text-md text-gray-700 mb-4">
-              You’ll find us tucked away on Goodramgate — just a 2-minute walk from York Minster. 
-              Whether you're stopping in for a flat white or a full brunch, we're right in the heart of the city.
+              You’ll find us on Ocean View Terrace — just a short stroll from the Brighton Pier.
+              Whether you're stopping in for a flat white or a full brunch, we're right by the sea.
             </p>
             <p className="text-md text-gray-700 mb-4">
               <strong>Address:</strong><br />
-              5C Goodramgate, York YO1 7LJ, United Kingdom
+              23 Ocean View Terrace, Brighton BN1 1AA, United Kingdom
             </p>
             <p className="text-md text-gray-700 mb-4">
               <strong>Phone:</strong><br />
-              <a href="tel:+447940210670" className="text-[#4b2e2e] hover:underline">07940 210670</a>
+              <a href="tel:+441273123456" className="text-sky-900 hover:underline">01273 123456</a>
             </p>
             <p className="text-md text-gray-700">
               <strong>Email:</strong><br />
-              <a href="mailto:hello@wheldrakes.co.uk" className="text-[#4b2e2e] hover:underline">hello@wheldrakes.co.uk</a>
+              <a href="mailto:hello@seasidebrew.co.uk" className="text-sky-900 hover:underline">hello@seasidebrew.co.uk</a>
             </p>
           </div>
 

--- a/app/gallery/page.js
+++ b/app/gallery/page.js
@@ -9,9 +9,9 @@ export default function GalleryPage() {
     <main>
       <section className="py-24 px-6 md:px-12 text-center bg-[#f9f7f4] border-b border-gray-100">
         <div className="max-w-4xl mx-auto">
-          <h1 className="text-4xl md:text-5xl font-bold mb-4 text-[#4b2e2e]">Our Gallery</h1>
+          <h1 className="text-4xl md:text-5xl font-bold mb-4 text-sky-900">Our Gallery</h1>
           <p className="text-lg text-gray-600 mb-10">
-            A look inside our cosy café and some of the fresh food and drinks we serve daily in York.
+            A glimpse inside our seaside café and some of the fresh food and drinks we serve daily in Brighton.
           </p>
         </div>
       </section>

--- a/config/siteConfig.js
+++ b/config/siteConfig.js
@@ -2,32 +2,32 @@
 
 export const siteConfig = {
   // Site Name
-  siteName: 'The Jester Berkhamsted',
+  siteName: 'Seaside Brew Brighton',
 
   // Metadata used across Next.js pages
   metadata: {
     base: {
-      title: 'Wheldrakes – Artisan Coffee & Brunch in York',
+      title: 'Seaside Brew – Coffee & Brunch by the Sea in Brighton',
       description:
-        'Wheldrakes is a beloved independent café in York, serving artisan coffee, fresh brunch, and homemade treats in a cosy, relaxed setting just minutes from York Minster.',
+        'Seaside Brew is a friendly independent café in Brighton serving speciality coffee, hearty brunches and homemade bakes just steps from the beach.',
       icons: {
         icon: '/favicon.ico',
       },
     },
     about: {
-      title: 'About | Wheldrakes',
+      title: 'About | Seaside Brew',
       description:
-        'Learn more about Wheldrakes Café in York – our story, our passion for fresh food and coffee, and the people behind the scenes.',
+        'Learn more about Seaside Brew in Brighton – our seaside story, our love of great coffee and brunch, and the team behind the counter.',
     },
     contact: {
-      title: 'Contact Us | Wheldrakes York',
+      title: 'Contact Us | Seaside Brew',
       description:
-        'Find our café, contact us via phone or email, and see where we are in York.',
+        'Find our Brighton café, get in touch by phone or email, and see where we are along the seafront.',
     },
     gallery: {
-      title: 'Gallery | Wheldrakes',
+      title: 'Gallery | Seaside Brew',
       description:
-        'Browse our cosy café, brunch plates, cakes and more from Wheldrakes in York.',
+        'Peek inside Seaside Brew and see our beachy café, tasty brunches and local coffee moments.',
     },
   },
 
@@ -41,29 +41,29 @@ export const siteConfig = {
 
   // Brand Colours (used in components as visual identity)
   brand: {
-    primary: 'text-amber-900',      // Used for headings (deep caramel brown)
-    secondary: 'bg-orange-50',      // Section backgrounds (warm cream tone)
-    accent: 'bg-amber-500',         // CTAs, buttons (warm amber)
-    textDark: 'text-zinc-900',      // Strong default text
-    textLight: 'text-white',        // Light-on-dark contrast
-    muted: 'text-zinc-400',         // Used for captions, footers
+    primary: 'text-sky-900',      // Used for headings (deep coastal blue)
+    secondary: 'bg-teal-50',      // Section backgrounds (soft seafoam)
+    accent: 'bg-sky-600',         // CTAs, buttons (bright ocean blue)
+    textDark: 'text-gray-900',    // Strong default text
+    textLight: 'text-white',      // Light-on-dark contrast
+    muted: 'text-gray-400',       // Used for captions, footers
   },
 
   // Class tokens mapped to Tailwind utility classes
   styles: {
-    bgLight: 'bg-orange-50',              // Background for Hero, About, etc.
-    bgPrimary: 'bg-amber-800',            // Background for buttons and banner
-    textPrimary: 'text-amber-900',        // Used in headings and CTAs
-    textMuted: 'text-zinc-500',           // For footer/subtle copy
-    textSubtle: 'text-neutral-700',       // For general body content
-    borderLight: 'border-zinc-200',       // Gallery, About, etc.
-    borderDark: 'border-zinc-400',        // Stronger dividers
+    bgLight: 'bg-teal-50',              // Background for Hero, About, etc.
+    bgPrimary: 'bg-sky-800',            // Background for buttons and banner
+    textPrimary: 'text-sky-900',        // Used in headings and CTAs
+    textMuted: 'text-gray-500',         // For footer/subtle copy
+    textSubtle: 'text-gray-700',        // For general body content
+    borderLight: 'border-gray-200',     // Gallery, About, etc.
+    borderDark: 'border-gray-400',      // Stronger dividers
   },
 
   // Banner strip at the top of the page
   banner: {
     show: true,
-    message: 'Now open every day from 8AM!',
+    message: 'Now serving Brighton from 7AM daily!',
     cta: {
       label: 'Explore Our Menu',
       href: '/menu',
@@ -98,12 +98,12 @@ export const siteConfig = {
 
   // Hero section content
   hero: {
-    heading: 'Cosy Coffee, Fresh Bakes, and Local Vibes',
-    subheading: 'Welcome to The Jester — your neighbourhood spot for artisan coffee, hearty brunches, and homemade treats in the heart of Berkhamsted.',
+    heading: 'Fresh Brews & Coastal Views',
+    subheading: 'Welcome to Seaside Brew — your go-to spot for speciality coffee, all-day brunch and homemade treats right by Brighton beach.',
     ctaPrimary: { label: 'Browse Our Menu', href: '/menu' },
     ctaSecondary: { label: 'See the Space', href: '/gallery' },
     image: 'https://images.pexels.com/photos/5857506/pexels-photo-5857506.jpeg',  // Hero image
-    tagline: 'Independent • Local • Loved',
+    tagline: 'Independent • Brighton Born • Beachside',
     values: [
       { icon: 'Coffee', label: 'Specialty Coffee' },
       { icon: 'Users', label: 'Friendly Staff' },
@@ -113,16 +113,16 @@ export const siteConfig = {
 
   // About Us content
   about: {
-    heading: 'Crafted with Care in Berkhamsted',
-    subheading: `At The Jester, it’s all about good vibes and great flavours. From rich coffee blends to fresh pastries and brunch classics, we’re a locally loved spot with an eye for quality and a heart for the community.`,
+    heading: 'Crafted with Care in Brighton',
+    subheading: `At Seaside Brew we mix Brighton's lively spirit with a love of quality. From locally roasted coffee to fresh pastries and brunch favourites, we're a welcoming hub for the community.`,
     features: [
       {
         title: 'Independent & Passionate',
-        text: 'Run by locals, for locals — The Jester is a laid-back hub where quality and community come first.',
+        text: 'Run by locals, for locals — Seaside Brew is a relaxed space where community and quality meet.',
       },
       {
         title: 'Brunch, Coffee, & Cakes',
-        text: 'Whether it’s your morning flat white, a weekend eggs benedict, or a sweet afternoon fix — we’ve got something for every mood.',
+        text: 'Whether it’s your morning flat white, a weekend eggs benedict or a sweet seaside treat — we’ve got something for every mood.',
       },
     ],
   },
@@ -130,15 +130,15 @@ export const siteConfig = {
   // Location / Contact section content
   location: {
     heading: 'Come Find Us',
-    text: 'You’ll find us right in the centre of Berkhamsted — the perfect pitstop for coffee, brunch, or a slice of cake.',
+    text: 'We are tucked just off the promenade — the perfect pitstop for coffee, brunch or a slice of cake by the sea.',
     address: [
-      'The Jester Café',
-      '173 High Street, Berkhamsted HP4 3HB, United Kingdom',
+      'Seaside Brew Café',
+      '23 Ocean View Terrace, Brighton BN1 1AA, United Kingdom',
     ],
     openingHours: [
-      'Monday–Sunday: 8:00 AM – 4:00 PM',
+      'Monday–Sunday: 7:00 AM – 5:00 PM',
     ],
-    mapEmbedUrl: 'https://www.google.com/maps/embed/v1/place?q=The+Jester,+173+High+St,+Berkhamsted+HP4+3HB,+UK&key=YOUR_API_KEY', // replace with real API key
+    mapEmbedUrl: 'https://www.google.com/maps/embed/v1/place?q=Seaside+Brew,+23+Ocean+View+Terrace,+Brighton,+UK&key=YOUR_API_KEY', // replace with real API key
   },
 
   // Gallery image grid
@@ -156,7 +156,7 @@ export const siteConfig = {
   // Testimonials section
   testimonials: {
     heading: 'What People Are Saying',
-    subheading: 'Real words from happy guests who’ve visited The Jester.',
+    subheading: 'Real words from happy guests who’ve visited Seaside Brew.',
     entries: [
       {
         quote: "Absolutely beautiful brunch and the best coffee in town. The cakes are divine and the staff couldn’t be friendlier.",


### PR DESCRIPTION
## Summary
- rebrand config for Seaside Brew
- update about page text and headings
- update contact page details
- tweak gallery intro

## Testing
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_68556dbf68b48321a2c3e8c89f67a6ad