### PR TITLE
Redesign hero for bakery

### DIFF
--- a/components/hero/Hero_1.jsx
+++ b/components/hero/Hero_1.jsx
@@ -1,68 +1,57 @@
-// HeroSection.jsx
-import Image from 'next/image';
-import { Coffee, Users, Heart } from 'lucide-react';
-import { siteConfig } from '@/config/siteConfig';
+import Image from 'next/image'
+import { Coffee, Users, Heart } from 'lucide-react'
+import { siteConfig } from '@/config/siteConfig'
 
 const iconMap = {
-  Coffee: <Coffee className={`w-5 h-5 ${siteConfig.styles.textPrimary}`} />,
-  Users: <Users className={`w-5 h-5 ${siteConfig.styles.textPrimary}`} />,
-  Heart: <Heart className={`w-5 h-5 ${siteConfig.styles.textPrimary}`} />,
-};
+  Coffee: <Coffee className={`w-5 h-5 text-${siteConfig.brand.primary}`} />,
+  Users: <Users className={`w-5 h-5 text-${siteConfig.brand.primary}`} />,
+  Heart: <Heart className={`w-5 h-5 text-${siteConfig.brand.primary}`} />,
+}
 
 export default function HeroSection() {
-  const hero = siteConfig.hero;
+  const hero = siteConfig.hero
 
   return (
-    <section
-      className={`${siteConfig.styles.bgLight} relative min-h-screen flex items-center py-24 px-6 md:px-12 ${siteConfig.fonts.baseClass}`}
-    >
-      <div className="absolute inset-0 bg-gradient-to-br from-amber-200 via-orange-100 to-transparent pointer-events-none" />
-      <div className="absolute -top-10 -left-10 w-40 h-40 bg-amber-300/50 rounded-full blur-2xl hidden md:block" />
-      <div className="max-w-7xl mx-auto flex flex-col lg:flex-row items-center gap-16">
-        <div className="lg:w-1/2 text-center lg:text-left">
-          <h1 className={`text-4xl md:text-5xl font-extrabold ${siteConfig.styles.textPrimary} leading-tight mb-6`}>
-            {hero.heading}
-          </h1>
-          <p className={`text-lg ${siteConfig.styles.textSubtle} mb-8`}>{hero.subheading}</p>
-          <div className="flex flex-wrap justify-center lg:justify-start gap-4 mb-12">
-            <a
-              href={hero.ctaPrimary.href}
-              className={`${siteConfig.styles.bgPrimary} ${siteConfig.styles.textLight} px-6 py-3 rounded-full font-medium shadow hover:opacity-90 transition`}
-            >
-              {hero.ctaPrimary.label}
-            </a>
-            <a
-              href={hero.ctaSecondary.href}
-              className={`border border-[${siteConfig.brand.primary}] ${siteConfig.styles.textPrimary} px-6 py-3 rounded-full font-medium hover:bg-[${siteConfig.brand.primary}]/10 transition`}
-            >
-              {hero.ctaSecondary.label}
-            </a>
-          </div>
-          <div className="flex justify-center lg:justify-start gap-6 text-sm text-gray-600">
-            {hero.values.map((item, i) => (
-              <div key={i} className="flex items-center gap-2">
-                {iconMap[item.icon]}
-                <span>{item.label}</span>
-              </div>
-            ))}
-          </div>
+    <section className={`relative min-h-screen flex items-center justify-center text-center ${siteConfig.fonts.baseClass}`}> 
+      <Image
+        src={hero.image}
+        alt={hero.imageAlt}
+        fill
+        priority
+        className="object-cover object-center"
+      />
+      <div className="absolute inset-0 bg-gradient-to-b from-white/80 via-white/60 to-white/30" />
+      <div className="relative z-10 max-w-3xl mx-auto px-6 md:px-12">
+        <h1 className={`text-5xl md:text-6xl font-extrabold mb-6 ${siteConfig.styles.textPrimary}`}>{hero.heading}</h1>
+        <p className={`text-lg md:text-xl mb-8 ${siteConfig.styles.textSubtle}`}>{hero.subheading}</p>
+        <div className="flex flex-wrap justify-center gap-4 mb-12">
+          <a
+            href={hero.ctaPrimary.href}
+            className={`${siteConfig.styles.bgPrimary} ${siteConfig.styles.textLight} px-6 py-3 rounded-full font-medium shadow hover:opacity-90 transition`}
+          >
+            {hero.ctaPrimary.label}
+          </a>
+          <a
+            href={hero.ctaSecondary.href}
+            className={`border border-${siteConfig.brand.primary} ${siteConfig.styles.textPrimary} px-6 py-3 rounded-full font-medium hover:bg-${siteConfig.brand.primary}/10 transition`}
+          >
+            {hero.ctaSecondary.label}
+          </a>
         </div>
-        <div className="relative lg:w-1/2">
-          <div className="relative w-full lg:max-w-xl mx-auto">
-            <Image
-              src={hero.image}
-              alt="Hero Image"
-              width={600}
-              height={400}
-              className="relative rounded-2xl shadow-lg object-cover"
-            />
-            <div className="absolute inset-0 rounded-2xl bg-black/20" />
-            <div className="absolute bottom-4 left-1/2 -translate-x-1/2 bg-amber-800 text-white text-sm px-4 py-1 rounded-full shadow-lg font-semibold tracking-wide">
-              {hero.tagline}
+        <div className="flex justify-center gap-6 text-sm text-gray-600">
+          {hero.values.map((item, i) => (
+            <div key={i} className="flex items-center gap-2">
+              {iconMap[item.icon]}
+              <span>{item.label}</span>
             </div>
-          </div>
+          ))}
         </div>
       </div>
+      {hero.tagline && (
+        <div className="absolute bottom-6 left-1/2 -translate-x-1/2 bg-amber-800 text-white text-sm px-4 py-1 rounded-full shadow-lg font-semibold tracking-wide">
+          {hero.tagline}
+        </div>
+      )}
     </section>
-  );
+  )
 }

--- a/config/siteConfig.js
+++ b/config/siteConfig.js
@@ -46,7 +46,7 @@ export const siteConfig = {
 
   // Brand Colours (used in components as visual identity)
   brand: {
-    primary: 'text-sky-900',      // Used for headings (deep coastal blue)
+    primary: 'sky-900',           // Used for headings (deep coastal blue)
     secondary: 'bg-teal-50',      // Section backgrounds (soft seafoam)
     accent: 'bg-sky-600',         // CTAs, buttons (bright ocean blue)
     textDark: 'text-gray-900',    // Strong default text
@@ -103,16 +103,18 @@ export const siteConfig = {
 
   // Hero section content
   hero: {
-    heading: 'Fresh Brews & Coastal Views',
-    subheading: 'Welcome to Seaside Brew — your go-to spot for speciality coffee, all-day brunch and homemade treats right by Brighton beach.',
-    ctaPrimary: { label: 'Browse Our Menu', href: '/menu' },
-    ctaSecondary: { label: 'See the Space', href: '/gallery' },
-    image: 'https://images.pexels.com/photos/5857506/pexels-photo-5857506.jpeg',  // Hero image
-    tagline: 'Independent • Brighton Born • Beachside',
+    heading: 'Baked Fresh Every Morning',
+    subheading:
+      'Welcome to Seaside Bakehouse — artisanal breads, pastries and coffee served daily by the coast.',
+    ctaPrimary: { label: 'View Menu', href: '/menu' },
+    ctaSecondary: { label: 'Our Gallery', href: '/gallery' },
+    image: 'https://images.pexels.com/photos/954199/pexels-photo-954199.jpeg',
+    imageAlt: 'Baker holding a tray of fresh bread',
+    tagline: 'Artisan Bakery • Coastal Flavours',
     values: [
       { icon: 'Coffee', label: 'Specialty Coffee' },
-      { icon: 'Users', label: 'Friendly Staff' },
-      { icon: 'Heart', label: 'Community Favourite' },
+      { icon: 'Heart', label: 'Baked with Love' },
+      { icon: 'Users', label: 'Community Hub' },
     ],
   },
 


### PR DESCRIPTION
## Summary
- make brand color configurable as plain color value
- update hero content for a bakery
- modernize `Hero_1` with fullscreen image and dynamic alt text

## Testing
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_685579655da083218c480c31e04cf225