### PR TITLE
Combine sticky banner and navbar

### DIFF
--- a/app/layout.js
+++ b/app/layout.js
@@ -35,8 +35,10 @@ export default function RootLayout({ children }) {
       <body
         className={`${baseFont.variable} ${headingFont.variable} ${accentFont ? accentFont.variable : ''} ${siteConfig.fonts.baseClass} antialiased`}
       >
-        <Banner />
-        <Nav />
+        <div className="sticky top-0 z-50">
+          <Banner />
+          <Nav />
+        </div>
         <main>{children}</main>
         <Footer />
       </body>

--- a/components/hero/Hero_1.jsx
+++ b/components/hero/Hero_1.jsx
@@ -12,7 +12,7 @@ export default function HeroSection() {
   const hero = siteConfig.hero
 
   return (
-    <section className={`relative min-h-screen flex items-center justify-center text-center ${siteConfig.fonts.baseClass}`}> 
+    <section className={`relative -mt-28 min-h-screen flex items-center justify-center text-center ${siteConfig.fonts.baseClass}`}>
       <Image
         src={hero.image}
         alt={hero.imageAlt}

--- a/components/navigation/Nav_1.jsx
+++ b/components/navigation/Nav_1.jsx
@@ -7,7 +7,7 @@ export default function Navbar() {
   const nav = siteConfig.nav;
 
   return (
-    <header className={`${siteConfig.styles.bgLight} w-full py-3 px-4 md:px-8 sticky top-0 z-50`}>
+    <header className="w-full py-3 px-4 md:px-8">
       <div className="max-w-7xl mx-auto bg-white rounded-full shadow-md px-6 py-6 flex items-center justify-between">
         <div className="flex items-center gap-8">
           <a href="/" className={`text-base font-semibold ${siteConfig.styles.textPrimary}`}>{siteConfig.siteName}</a>


### PR DESCRIPTION
## Summary
- keep banner and navbar inside a single sticky wrapper
- remove sticky/full‑width background from `Nav_1`
- pull hero section up so its background shows behind the navbar

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_68557dcab3c88321baf4761aabe34a89